### PR TITLE
added static versions of bindAsArray and bindAsObject

### DIFF
--- a/src/reactfire.js
+++ b/src/reactfire.js
@@ -1,3 +1,18 @@
+function StaticMaker(method,firebaseRef,bindVar,cancelCallback){
+  return {
+    componentWillMount: function(){
+      this.firebaseRefs = this.firebaseRefs || {};
+      this.firebaseListeners = this.firebaseListeners || {};
+      var tosteal = ["bindAsArray","bindAsObject","_bind","_validateBindVar","unbind","_isArray","_toArray"];
+      for(var m in tosteal){
+        this[tosteal[m]] = ReactFireMixin[tosteal[m]];
+      }
+      this[method](firebaseRef,bindVar,cancelCallback);
+    },
+    componentWillUnmount: ReactFireMixin.componentWillUnmount
+  };
+}
+
 var ReactFireMixin = {
   /********************/
   /*  MIXIN LIFETIME  */
@@ -23,12 +38,20 @@ var ReactFireMixin = {
   /*************/
   /* Creates a binding between Firebase and the inputted bind variable as an array */
   bindAsArray: function(firebaseRef, bindVar, cancelCallback) {
-    this._bind(firebaseRef, bindVar, cancelCallback, true);
+    if (!this.setState){
+      return StaticMaker("bindAsArray",firebaseRef,bindVar,cancelCallback);
+    } else {
+      this._bind(firebaseRef, bindVar, cancelCallback, true);
+    }
   },
 
   /* Creates a binding between Firebase and the inputted bind variable as an object */
   bindAsObject: function(firebaseRef, bindVar, cancelCallback) {
-    this._bind(firebaseRef, bindVar, cancelCallback, false);
+    if (!this.setState){
+      return StaticMaker("bindAsObject",firebaseRef,bindVar,cancelCallback);
+    } else {
+      this._bind(firebaseRef, bindVar, cancelCallback, false);
+    }
   },
 
   /* Creates a binding between Firebase and the inputted bind variable as either an array or object */
@@ -61,7 +84,7 @@ var ReactFireMixin = {
         newState[bindVar] = dataSnapshot.val();
       }
       this.setState(newState);
-    }.bind(this), cancelCallback);
+    }.bind(this), this[cancelCallback] || cancelCallback);
   },
 
   /* Removes the binding between Firebase and the inputted bind variable */

--- a/src/reactfire.js
+++ b/src/reactfire.js
@@ -1,10 +1,10 @@
-function StaticMaker(method,firebaseRef,bindVar,cancelCallback){
+function staticMaker(method,firebaseRef,bindVar,cancelCallback){
   return {
     componentWillMount: function(){
       this.firebaseRefs = this.firebaseRefs || {};
       this.firebaseListeners = this.firebaseListeners || {};
       var tosteal = ["bindAsArray","bindAsObject","_bind","_validateBindVar","unbind","_isArray","_toArray"];
-      for(var m in tosteal){
+      for(var m=0; m < tosteal.length; m++){
         this[tosteal[m]] = ReactFireMixin[tosteal[m]];
       }
       this[method](firebaseRef,bindVar,cancelCallback);
@@ -39,7 +39,7 @@ var ReactFireMixin = {
   /* Creates a binding between Firebase and the inputted bind variable as an array */
   bindAsArray: function(firebaseRef, bindVar, cancelCallback) {
     if (!this.setState){
-      return StaticMaker("bindAsArray",firebaseRef,bindVar,cancelCallback);
+      return staticMaker("bindAsArray",firebaseRef,bindVar,cancelCallback);
     } else {
       this._bind(firebaseRef, bindVar, cancelCallback, true);
     }
@@ -48,7 +48,7 @@ var ReactFireMixin = {
   /* Creates a binding between Firebase and the inputted bind variable as an object */
   bindAsObject: function(firebaseRef, bindVar, cancelCallback) {
     if (!this.setState){
-      return StaticMaker("bindAsObject",firebaseRef,bindVar,cancelCallback);
+      return staticMaker("bindAsObject",firebaseRef,bindVar,cancelCallback);
     } else {
       this._bind(firebaseRef, bindVar, cancelCallback, false);
     }

--- a/tests/specs/reactfire.spec.js
+++ b/tests/specs/reactfire.spec.js
@@ -121,6 +121,27 @@ describe("ReactFireMixin Tests:", function() {
       React.render(new TestComponent(), document.body);
     });
 
+    it("bindAsArray() static call binds to remote Firebase data as an array", function(done) {
+      var TestComponent = React.createClass({
+        mixins: [ReactFireMixin.bindAsArray(firebaseRef,"items")],
+
+        componentDidMount: function() {
+          firebaseRef.set({ a: 1, b: 2, c: 3 });
+        },
+
+        componentDidUpdate: function(prevProps, prevState) {
+          expect(this.state).toEqual({ items: [1, 2, 3] });
+          done();
+        },
+
+        render: function() {
+          return React.DOM.div(null, "Testing");
+        }
+      });
+
+      React.render(new TestComponent(), document.body);
+    });
+
     it("bindAsArray() binds to remote Firebase data as an array (limit query)", function(done) {
       var TestComponent = React.createClass({
         mixins: [ReactFireMixin],
@@ -243,6 +264,27 @@ describe("ReactFireMixin Tests:", function() {
         componentWillMount: function() {
           this.bindAsObject(firebaseRef, "items");
         },
+
+        componentDidMount: function() {
+          firebaseRef.set({ a: 1, b: 2, c: 3 });
+        },
+
+        componentDidUpdate: function(prevProps, prevState) {
+          expect(this.state).toEqual({ items: { a: 1, b: 2, c: 3 } });
+          done();
+        },
+
+        render: function() {
+          return React.DOM.div(null, "Testing");
+        }
+      });
+
+      React.render(new TestComponent(), document.body);
+    });
+
+    it("bindAsObject() static binds to remote Firebase data as an object", function(done) {
+      var TestComponent = React.createClass({
+        mixins: [ReactFireMixin.bindAsObject(firebaseRef, "items")],
 
         componentDidMount: function() {
           firebaseRef.set({ a: 1, b: 2, c: 3 });


### PR DESCRIPTION
This PR employs a [mixin factory pattern](http://blog.krawaller.se/posts/reflux-refinement/) to make a static version of `bindAsArray` and `bindAsObject`. 

Instead of doing this...

```javascript
var ExampleComponent = React.createClass({
  mixins: [ReactFireMixin],
  componentWillMount: function(){
    this.bindAsArray(firebaseRef,"propname",this.cancel);
  }
});
```

...you can simply do this:

```javascript
var ExampleComponent = React.createClass({
  mixins: [ReactFireMixin.bindAsArray(firebaseRef,"propname","cancel")],
});
```
The static versions will then set up the `componentWillMount` method for you automatically.

To harmonise with not being able to supply `this.cancel` in the static method (since `this` doesn't point to the instance at that point in time) I made all versions also work with a string as a cancel argument, which is then assumed to be the name of a method on the instance.