### PR TITLE
Added _ref property to array objects

### DIFF
--- a/src/reactfire.js
+++ b/src/reactfire.js
@@ -126,7 +126,7 @@ var ReactFireMixin = {
         for (var key in obj) {
           if (obj.hasOwnProperty(key)) {
             var child = obj[key];
-            child['_ref'] = key;  
+            child._ref = key;  
             out.push(child);
           }
         }

--- a/src/reactfire.js
+++ b/src/reactfire.js
@@ -125,7 +125,9 @@ var ReactFireMixin = {
       else if (typeof(obj) === "object") {
         for (var key in obj) {
           if (obj.hasOwnProperty(key)) {
-            out.push(obj[key]);
+            var child = obj[key];
+            child['_ref'] = key;  
+            out.push(child);
           }
         }
       }


### PR DESCRIPTION
When converting a firebase snapshot into an array, this adds the individual location refs to the object in order to make subsequent manipulation easier. This is one way to address issue 33.