### PR TITLE
Ensure array items are returned in the correct order

### DIFF
--- a/src/reactfire.js
+++ b/src/reactfire.js
@@ -54,11 +54,17 @@ var ReactFireMixin = {
     this.firebaseRefs[bindVar] = firebaseRef.ref();
     this.firebaseListeners[bindVar] = firebaseRef.on("value", function(dataSnapshot) {
       var newState = {};
+      var data = {};
+
+      dataSnapshot.forEach(function(child) {
+        data[child.key()] = child.val();
+      });
+
       if (bindAsArray) {
-        newState[bindVar] = this._toArray(dataSnapshot.val());
+        newState[bindVar] = this._toArray(data);
       }
       else {
-        newState[bindVar] = dataSnapshot.val();
+        newState[bindVar] = data;
       }
       this.setState(newState);
     }.bind(this), cancelCallback);


### PR DESCRIPTION
This pull request fixes #36 by using the [`DataSnapshot.forEach`](https://www.firebase.com/docs/web/api/datasnapshot/foreach.html) method to build up an array before passing it to React. This ensures that arrays are sent to React in the order which the query specified.