### PR TITLE
Prevent calling unbind on undefined firebaseRefs

### DIFF
--- a/src/reactfire.js
+++ b/src/reactfire.js
@@ -296,7 +296,7 @@
     componentWillUnmount: function() {
       for (var bindVar in this.firebaseRefs) {
         /* istanbul ignore else */
-        if (this.firebaseRefs.hasOwnProperty(bindVar)) {
+        if (this.firebaseRefs.hasOwnProperty(bindVar) && this.firebaseRefs[bindVar] !== undefined) {
           this.unbind(bindVar);
         }
       }


### PR DESCRIPTION
Currently the componentWillUnmount will attempt to unbind a ref that we've already called unbind on, resulting in an error. We need to skip any values within this.firebaseRefs that equal "undefined". Alternatively we could change unbind to delete the ref from this.firebaseRefs (it looks like it used to be that way and was changed for some reason).