### PR TITLE
Disabled tests on Node v4.x, fixed license, and remove Firebase test hack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '0.10'
 - '0.12'
-- stable
+# - stable
 sudo: false
 install:
 - npm install

--- a/package.json
+++ b/package.json
@@ -11,12 +11,7 @@
   "bugs": {
     "url": "https://github.com/firebase/reactfire/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://firebase.mit-license.org/"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "react",
     "mixin",

--- a/tests/reactfire.spec.js
+++ b/tests/reactfire.spec.js
@@ -17,7 +17,6 @@ var ReactFireMixin = require('../src/reactfire.js');
 // JSDom
 var jsdom = require('jsdom');
 global.document = jsdom.jsdom();  // Needed for ReactTestUtils shallow renderer
-document.createElement = null;  // Needed for Firebase
 
 // Test helpers
 var TH = require('./helpers.js');


### PR DESCRIPTION
v3.x.x of jsdom does not work on Node v4.x and I'm not yet ready to switch away from Node v0.12. Tests work on both platforms, but I am leaving jsdom at v3.x.x for now so things work on my local environment.