### PR TITLE
track value callback completion in firebaseLoads

### DIFF
--- a/src/reactfire.js
+++ b/src/reactfire.js
@@ -118,6 +118,7 @@
     var value = snapshot.val();
 
     this.data[bindVar] = _createRecord(key, value);
+    this.firebaseLoads[bindVar] = true;
 
     this.setState(this.data);
   }
@@ -229,6 +230,15 @@
     this.setState(this.data);
   }
 
+  /**
+   * 'value' listener which updates the 'load' state of the bound state variable.
+   *
+   * @param {string} bindVar The state variable to which the data is being bound.
+   */
+  function _arrayValue(bindVar) {
+    this.firebaseLoads[bindVar] = true;
+    this.setState(this.data);
+  }
 
   /*************/
   /*  BINDING  */
@@ -266,7 +276,8 @@
         child_added: firebaseRef.on('child_added', _arrayChildAdded.bind(this, bindVar), cancelCallback),
         child_removed: firebaseRef.on('child_removed', _arrayChildRemoved.bind(this, bindVar), cancelCallback),
         child_changed: firebaseRef.on('child_changed', _arrayChildChanged.bind(this, bindVar), cancelCallback),
-        child_moved: firebaseRef.on('child_moved', _arrayChildMoved.bind(this, bindVar), cancelCallback)
+        child_moved: firebaseRef.on('child_moved', _arrayChildMoved.bind(this, bindVar), cancelCallback),
+        value: firebaseRef.on('value', _arrayValue.bind(this, bindVar), cancelCallback)
       };
     } else {
       // Add listener for 'value' event
@@ -288,6 +299,7 @@
       this.data = {};
       this.firebaseRefs = {};
       this.firebaseListeners = {};
+      this.firebaseLoads = {};
     },
 
     /**


### PR DESCRIPTION
use case: no data exists vs data not yet loaded.
scenario: this.bindAsArray(ref, "items"); without firebaseLoads
there is no way to tell why there are no items, which is a problem
if we want to show a "no items" message.  if we rely on
items.length == 0 we will see the "no items" message flicker
before the data is loaded.