### PR TITLE
fix typo

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -81,7 +81,7 @@ which is run once, immediately before the initial rendering of the component:
 
 ```js
 componentWillMount: function() {
-  this.firebaseRef = firebase.database.ref("items");
+  this.firebaseRef = firebase.database().ref("items");
   this.firebaseRef.on("child_added", function(dataSnapshot) {
     this.items.push(dataSnapshot.val());
     this.setState({


### PR DESCRIPTION
### Description

a forgotten `()` after `database`