### PR TITLE
Marking ReactFire as deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,254 @@
-# ReactFire [![Build Status](https://travis-ci.org/firebase/reactfire.svg?branch=master)](https://travis-ci.org/firebase/reactfire) [![Coverage Status](https://coveralls.io/repos/firebase/reactfire/badge.svg?branch=master&service=github)](https://coveralls.io/github/firebase/reactfire?branch=master) [![GitHub version](https://badge.fury.io/gh/firebase%2Freactfire.svg)](http://badge.fury.io/gh/firebase%2Freactfire)
+# ReactFire is deprecated
 
+ReactFire is deprecated. To use Firebase on React application you can use either:
+ - The [Firebase JS SDK](https://www.npmjs.com/package/firebase) directly. See below for [Firebase + React samples](#using-the-firebase-js-sdk-in-react)) and [migration guides](#migrating-from-reactfire).
+ - The [Re-base](https://www.npmjs.com/package/re-base) library which is close to reactfire in design.
+ - The [react-redux-firebase](https://github.com/prescottprue/react-redux-firebase) library if you are using Redux in your React app.
+ 
+> To access the former README you can check out the [v1.0.0 tag](https://github.com/firebase/reactfire/tree/v1.0.0)
 
-[ReactJS](https://facebook.github.io/react/) is a framework for building large, complex user
-interfaces. [Firebase](https://firebase.google.com/) complements it perfectly by providing an
-easy-to-use, realtime data source for populating the `state` of React components. With ReactFire, it
-only takes a few lines of JavaScript to integrate Firebase data into React apps via the
-`ReactFireMixin`.
+## Using the Firebase JS SDK in React
 
+To use the Firebase JS SDK in React, you can follow these guidelines:
+ - Initialize Firebase in your app once, for instance outside the React components or in a separate module and export the firebase App.
+ - Create your Firebase data observers in `componentDidMount` lifecycle methods.
+ - Map your Firebase data to the local state in the data observers.
+ - Un-subscribe your Firebase data observers in `componentWillUnmount` lifecycle methods to avoid memory leaks and unintended behaviors.
+ - When updating data: update the data on Firebase directly. Do not update the local state because it won't update  the data on Firebase but updating Firebase will trigger your local observers instantly.
+ 
+ 
+### Initialize Firebase
 
-## Table of Contents
+Initialize Firebase once, for example in a separate module (e.g. `firebase.js`) and export the Firebase app. You can find more details on the [web](https://firebase.google.com/docs/web/setup) setup guides:
 
- * [Getting Started With Firebase](#getting-started-with-firebase)
- * [Downloading ReactFire](#downloading-reactfire)
- * [Documentation](#documentation)
- * [Examples](#examples)
- * [Release Notes](https://github.com/firebase/reactfire/releases)
- * [Migration Guides](#migration-guides)
- * [Contributing](#contributing)
+**firebase.js**
+```js
+// Import the Firebase modules that you need in your app.
+import firebase from 'firebase/app';
+import 'firebase/auth';
+import 'firebase/database';
+import 'firebase/datastore';
 
-
-## Getting Started With Firebase
-
-ReactFire requires [Firebase](https://firebase.google.com/) in order to sync and store data.
-Firebase is a suite of integrated products designed to help you develop your app, grow your user
-base, and earn money. You can [sign up here for a free account](https://console.firebase.google.com/).
-
-
-## Downloading ReactFire
-
-In order to use ReactFire in your project, you need to include the following files in your HTML:
-
-```html
-<!-- React -->
-<script src="https://fb.me/react-15.3.0.min.js"></script>
-<script src="https://fb.me/react-dom-15.3.0.min.js"></script>
-
-<!-- Firebase -->
-<script src="https://www.gstatic.com/firebasejs/3.3.0/firebase.js"></script>
-
-<!-- ReactFire -->
-<script src="https://cdn.firebase.com/libs/reactfire/1.0.0/reactfire.min.js"></script>
+// Initalize and export Firebase.
+const config = {
+  apiKey: '<YOUR-API-KEY>',
+  authDomain: '<YOUR-AUTH-DOMAIN>',
+  databaseURL: 'https://<YOUR-DATABASE-NAME>.firebaseio.com',
+  projectId: '<YOUR-PROJECT-ID>',
+  storageBucket: '<YOUR-STORAGE-BUCKET>.appspot.com',
+  messagingSenderId: '<YOUR-MESSAGING-SENDER-ID>'
+};
+export default firebase.initializeApp(config);
 ```
 
-You can also install ReactFire via npm or Bower. If downloading via npm, you will have to install
-React and Firebase separately (that is, they are `peerDependencies`):
 
-```bash
-$ npm install reactfire react firebase --save
+### Firebase Auth
+
+Here is an example of how you can map the Firebase authentication state to your React component's local state:
+
+```js
+import firebase from './firebase.js';
+
+class MyComponent extends React.Component {
+  state = {
+    isSignedIn: false,
+    userProfile: null
+  };
+  
+  componentDidMount() {
+    this.deregisterAuthObservable = firebase.auth().onAuthStateChanged((user) => {
+      this.setState({ isSignedIn: !!user, userProfile: user });
+    });
+  }
+  
+  componentWillUnmount() {
+    this.deregisterAuthObservable();
+  }
+  
+  // ...
+}
 ```
 
-On Bower, the React and Firebase dependencies will be downloaded automatically alongside ReactFire:
 
+### Firebase Realtime Database
 
-```bash
-$ bower install reactfire --save
+Here is an example of how you can map data from the Realtime Databaseto your React component's local state:
+
+```js
+import firebase from './firebase.js';
+
+class MyComponent extends React.Component {
+  state = {
+    someData: {}
+  };
+  
+  componentDidMount() {
+    // Updating the `someData` local state attribute when the Firebase Realtime Database data
+    // under the '/someData' path changes.
+    this.firebaseRef = firebase.database().ref('/someData');
+    this.firebaseCallback = this.firebaseRef.on('value', (snap) => {      
+      this.setState({ someData: snap.val() });
+    });
+  }
+  
+  componentWillUnmount() {
+    // Un-register the listener on '/someData'.
+    this.firebaseRef.off('value', this.firebaseCallback);
+  }
+  
+  // ...
+}
 ```
 
-## Documentation
 
-* [Quickstart](docs/quickstart.md)
-* [Guide](docs/guide.md)
-* [API Reference](docs/reference.md)
+### Firebase Cloud Datastore
+
+Here is an example of how you can map data from the Cloud Datastore in a React component:
+
+```js
+import firebase from './firebase.js';
+
+class MyComponent extends React.Component {
+  state = {
+    someCollection: {},
+    someDocument: null
+  };
+  
+  componentDidMount() {
+    // Updating the `someCollection` local state attribute when the Cloud Firestore 'someCollection' collection changes.
+    this.unsubscribeCollectionObserver = firebase.firestore().collection('someCollection').onSnapshot((snap) => {
+      const someCollection = {};
+      snap.forEach((docSnapshot) => {
+        someCollection[docSnapshot.id] = docSnapshot.data();
+      });
+      this.setState({ someCollection: someCollection });
+    });
+    
+    // Updating the `someDocument` local state attribute when the Cloud Firestore 'someDocument' document changes.
+    this.unsubscribeDocumentObserver = firebase.firestore().doc('/collection/someDocument').onSnapshot((snap) => {
+      this.setState({ someDocument: snap.data() });
+    });
+  }
+  
+  componentWillUnmount() {
+    // Un-register the listeners.
+    this.unsubscribeCollectionObserver();
+    this.unsubscribeDocumentObserver();
+  }
+  
+  // ...
+}
+```
+
+### Updating data
+
+When updating data, do not set the local state. Setting the local state will not update Firebase. Instead you should update your data on Firebase directly, this will trigger any observers that you have setup locally instantly from cache.
+
+For instance, let's take an app that has a list of todo items stored on Firebase. It also has a text field and a button to add new todos:
+
+```js
+import firebase from './firebase.js';
+
+class MyComponent extends React.Component {
+  state = {
+    todoList: {},
+    newTodoText: ''
+  };
+  
+  componentDidMount() {
+    // Updating the `todoList` local state attribute when the Firebase Realtime Database data
+    // under the '/todoList' path changes.
+    this.firebaseRef = firebase.database().ref('/todoList');
+    this.firebaseCallback = this.firebaseRef.on('value', (snap) => {      
+      this.setState({ todoList: snap.val() });
+    });
+  }
+  
+  componentWillUnmount() {
+    // Un-register the listener on '/todoList'.
+    this.firebaseRef.off('value', this.firebaseCallback);
+  }
+  
+  onSubmit(e) {
+    e.preventDefault();
+    // Add the new todo to Firebase.
+    this.firebaseRef.push({
+      text: this.state.newTodoText
+    });
+    // Clearing the text field.
+    this.setState({text: ''});
+  }
+  
+  // ...
+}
+```
+
+Note how we are not updating the `todoList` in the local state. You only need to update Firebase and the Firebase observer that was set up will take care of propagating the changes and updating the local state.
 
 
-## Examples
+## Migrating from ReactFire
 
-* [Todo App](examples/todoApp)
-* [Comments Box](examples/commentsBox)
+To migrate from ReactFire to using the Firebase JS SDK first remove the `ReactFireMixin` that was applied to any of your React components.
+
+### Migrate `bindAsObject` calls
+
+In all component that are using [bindAsObject(firebaseRef, bindVar, cancelCallback)](https://github.com/firebase/reactfire/blob/master/docs/reference.md#bindasobjectfirebaseref-bindvar-cancelcallback) change from:
+
+```js
+componentWillMount: function() {
+  var ref = firebase.database().ref().child("users/fred");
+  this.bindAsObject(ref, "user");
+}
+
+componentWillUnmount: function() {
+  this.unbind("user");
+}
+```
+
+to:
+
+```js
+componentDidMount: function() {
+  this.firebaseCallback = firebase.database().ref('/users/fred').on('value', function(snap) {      
+    this.setState({ user: snap.val() });
+  });
+}
+  
+componentWillUnmount: function() {
+  firebase.database().ref('/users/fred').off('value', this.firebaseCallback);
+}
+```
 
 
-## Migration Guides
+### Migrate `bindAsObject` calls
 
-* [Migrating from ReactFire `0.7.0` to `1.x.x`](docs/migration/070-to-1XX.md)
+In all component that are using [bindAsArray(firebaseRef, bindVar, cancelCallback)](https://github.com/firebase/reactfire/blob/master/docs/reference.md#bindasarrayfirebaseref-bindvar-cancelcallback) change from:
 
+```js
+componentWillMount: function() {
+  var ref = firebase.database().ref("items");
+  this.bindAsArray(ref, "items");
+}
 
-## Contributing
+componentWillUnmount: function() {
+  this.unbind("items");
+}
+```
 
-If you'd like to contribute to ReactFire, please first read through our [contribution
-guidelines](.github/CONTRIBUTING.md). Local setup instructions are available [here](.github/CONTRIBUTING.md#local-setup).
+to:
+
+```js
+componentDidMount: function() {
+  this.firebaseCallback = firebase.database().ref('/items').on('value', function(snap) {    
+    var items = [];
+    snap.forEach(function(itemSnap) {
+      items.push(itemSnap.val());
+    });
+    this.setState({ items: items });
+  });
+}
+  
+componentWillUnmount: function() {
+  firebase.database().ref('/items').off('value', this.firebaseCallback);
+}
+```


### PR DESCRIPTION
Also adding a refreshed Firebase in React guide and a migration guide from ReactFire to using the JS SDK.

Rationale:

Reactfire is currently based on a deprecated/bad-practice technology (mixins).
Furthermore the current JS SDK can be used directly in React components and there are two 3rd-party Firebase libraries for React (re-base and react-redux-firebase) which are actively developed and of high quality.


fixes #132